### PR TITLE
Upload Markdown file produced by the E2E test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,11 @@ jobs:
     - run: npm run build
     - run: npm run pack
     - run: npm test
+    - uses: actions/upload-artifact@v2
+      with:
+        # This file gets produced by main.test.ts
+        name: test-markdown
+        path: test/result.md
 
   run:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The E2E test will fail only if running the action fails.  Upload the Markdown file so it can be inspected manually for errors.